### PR TITLE
Frankwkw patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Install with Composer: `composer require "rmasters/swapi:~1.0"`.
 
+10/02/2018 - Fix by Frank Wong to support array when mapping via JsonMapper 0.11.
+
 ```php
 require_once __DIR__ . '/vendor/autoload.php';
 use SWAPI\SWAPI;

--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,16 @@
             "email": "ross@rossmasters.com",
             "homepage": "http://codinghobo.com/",
             "role": "Developer"
+        },
+        {
+            "name": "Frank Wong",
+            "email": "frankwkw@gmail.com"
         }
     ],
     "require": {
         "guzzlehttp/guzzle": "~5.0",
         "psr/log": "~1.0",
-        "netresearch/jsonmapper": "~0.4"
+        "netresearch/jsonmapper": "~0.11"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/src/Endpoints/Endpoint.php
+++ b/src/Endpoints/Endpoint.php
@@ -52,6 +52,7 @@ class Endpoint
 
     protected function hydrateOne(array $data, $modelInstance)
     {
+        $this->mapper->bEnforceMapType = false;
         return $this->mapper->map($data, $modelInstance);
     }
 

--- a/src/Endpoints/Endpoint.php
+++ b/src/Endpoints/Endpoint.php
@@ -40,6 +40,7 @@ class Endpoint
     public function setMapper(JsonMapper $mapper)
     {
         $this->mapper = $mapper;
+        $this->mapper->bEnforceMapType = false;
     }
 
     protected function handleResponse(Response $response, Request $request, $default = null)
@@ -52,7 +53,6 @@ class Endpoint
 
     protected function hydrateOne(array $data, $modelInstance)
     {
-        $this->mapper->bEnforceMapType = false;
         return $this->mapper->map($data, $modelInstance);
     }
 


### PR DESCRIPTION
This pull request fixes the problem in SWAPI 0.2 where it is no longer compatible with JsonMapper 0.11 because it does not allow passing an array into the Map function.